### PR TITLE
fix: upgrade alpine base image to supported version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3.15:latest
+ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3:latest
 ARG VERSION=latest
 
 FROM ubuntu:20.04 as builder


### PR DESCRIPTION
Alpine 3.15 no longer supported by Alpine maintainers.

```
Alpine 3.15.11 is no longer supported by the Alpine maintainers. Vulnerability detection may be affected by a lack of security updates.
```

Upgrade base image to use latest alpine:3 available.